### PR TITLE
Centralize color styles

### DIFF
--- a/src/components/global-components/Footer/Footer.module.css
+++ b/src/components/global-components/Footer/Footer.module.css
@@ -3,6 +3,6 @@
   justify-content: center;
   align-items: center;
   width: 100%;
-  color: var(--color-text-for-all-footers) !important;
+  color: var(--footer-text) !important;
   font-size: 12px !important;
 }

--- a/src/components/global-components/Header/Header.module.css
+++ b/src/components/global-components/Header/Header.module.css
@@ -1,6 +1,6 @@
 .header {
-  background-color: var(--background-color-for-all-headers) !important;
-  color: var(--color-text-for-all-headers) !important;
+  background-color: var(--header-background) !important;
+  color: var(--header-text) !important;
   padding: 15px !important;
   font-size: 24px !important;
 }

--- a/src/components/global-components/InfoCard/InfoCard.module.css
+++ b/src/components/global-components/InfoCard/InfoCard.module.css
@@ -1,7 +1,7 @@
 .infoCard {
   margin-right: 40px !important;
-  background-color: #2b7a78 !important;
-  color: #feffff !important;
+  background-color: var(--info-card-background) !important;
+  color: var(--info-card-text) !important;
   border-radius: 15px;
   box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.2), 0px 4px 10px rgba(0, 0, 0, 0.1);
   position: relative;

--- a/src/components/global-components/InputDate/InputDate.module.css
+++ b/src/components/global-components/InputDate/InputDate.module.css
@@ -4,17 +4,17 @@
 
 .inputDate :global(.MuiOutlinedInput-root),
 .inputDate :global(.MuiInputLabel-root) {
-  color: #feffff !important;
+  color: var(--input-date-text) !important;
 }
 
 .inputDate :global(.MuiOutlinedInput-notchedOutline) {
-  border-color: #3aafa9 !important;
+  border-color: var(--input-date-border) !important;
 }
 
 .inputDate :global(.MuiInputLabel-root) {
-  color: #feffff !important;
+  color: var(--input-date-text) !important;
 }
 
 .inputDate :global(.MuiOutlineInput-notchedOutline) {
-  border: 1px solid #feffff !important;
+  border: 1px solid var(--input-date-fieldset-border) !important;
 }

--- a/src/components/global-components/Spinner/Spinner.module.css
+++ b/src/components/global-components/Spinner/Spinner.module.css
@@ -4,5 +4,5 @@
 }
 
 .spinner {
-  color: var(--color-circular-progress) !important;
+  color: var(--progress-color) !important;
 }

--- a/src/components/pages-components/AdminTasks/TasksList/TasksList.module.css
+++ b/src/components/pages-components/AdminTasks/TasksList/TasksList.module.css
@@ -10,6 +10,6 @@
 }
 
 .lists {
-  background-color: #2b7878 !important;
+  background-color: var(--tasks-list-background) !important;
   margin-top: 1rem !important;
 }

--- a/src/components/pages-components/Login/CardFlip/CardFlip.module.css
+++ b/src/components/pages-components/Login/CardFlip/CardFlip.module.css
@@ -1,5 +1,5 @@
 .heading {
-  color: #feffff !important;
+  color: var(--login-button-text) !important;
   font-weight: bold;
   text-align: center;
   margin-top: 2rem;
@@ -24,9 +24,9 @@
 }
 
 .login {
-  background-color: #2b7a78 !important;
-  color: var(--color-text-for-btn-login) !important;
-  box-shadow: 0 0 20px var(--color-box-shadow-for-btn-login) !important;
+  background-color: var(--header-background) !important;
+  color: var(--login-button-text) !important;
+  box-shadow: 0 0 20px var(--login-button-shadow) !important;
   width: 80%;
   max-width: 400px;
   font-weight: bold;
@@ -38,9 +38,9 @@
 }
 
 .cardFront {
-  background-color: var(--color-background-for-btn-login) !important;
-  color: var(--color-text-for-btn-login) !important;
-  box-shadow: 0 0 20px var(--color-box-shadow-for-btn-login) !important;
+  background-color: var(--login-button-background) !important;
+  color: var(--login-button-text) !important;
+  box-shadow: 0 0 20px var(--login-button-shadow) !important;
   font-weight: bold;
   font-size: 24px !important;
   text-align: center;
@@ -62,7 +62,7 @@
 }
 
 .cardBack {
-  background-color: var(--color-background-for-btn-login);
+  background-color: var(--login-button-background);
   transform: rotateY(180deg);
   display: flex;
   flex-direction: column;
@@ -73,7 +73,7 @@
 }
 
 .backLink {
-  color: var(--color-text-for-all-headers-and-footers) !important;
+  color: var(--header-text) !important;
   font-size: 30px !important;
   font-weight: bold;
   text-decoration: none;

--- a/src/components/pages-components/ManageRules/AddNewRule/AddNewRule.module.css
+++ b/src/components/pages-components/ManageRules/AddNewRule/AddNewRule.module.css
@@ -4,14 +4,14 @@
 }
 
 .addNewRuleTextField fieldset {
-  border: 1px solid #17252a !important;
+  border: 1px solid var(--manage-rules-border) !important;
 }
 
 .addNewRuleTextField input,
 .addNewRuleTextField label,
 .addNewRuleTextField span,
 .addNewRuleTextField textarea {
-  color: #17252a !important;
+  color: var(--manage-rules-text) !important;
 }
 
 .addNewRuleContainer {

--- a/src/components/pages-components/ManageRules/TaskAssignedToRule/TaskAssignedToRule.module.css
+++ b/src/components/pages-components/ManageRules/TaskAssignedToRule/TaskAssignedToRule.module.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   align-items: center;
   padding: 6px 12px;
-  background-color: #2b7a78;
+  background-color: var(--header-background);
   border-radius: 6px;
   height: auto;
   flex: 0 0 auto;
@@ -22,7 +22,7 @@
   border-radius: 5px;
   padding: 5px 10px;
   font-size: 0.8rem;
-  color: #17252a !important;
-  background-color: #3aa3a9 !important;
+  color: var(--manage-rules-text) !important;
+  background-color: var(--draggable-background) !important;
   margin: 5px;
 }

--- a/src/components/pages-components/ManageRules/TasksRow/TasksRow.module.css
+++ b/src/components/pages-components/ManageRules/TasksRow/TasksRow.module.css
@@ -5,7 +5,7 @@
 }
 
 .addTaskButton {
-  background-color: #2b7a78 !important;
+  background-color: var(--header-background) !important;
   max-height: 50px;
   align-self: center;
 }

--- a/src/components/pages-components/Results/SelectOption/SelectOption.module.css
+++ b/src/components/pages-components/Results/SelectOption/SelectOption.module.css
@@ -1,3 +1,3 @@
 .select {
-  color: #feffff;
+  color: var(--light-color);
 }

--- a/src/components/pages-components/SeeRule/ChangeRuleOrder/ChangeRuleOrder.module.css
+++ b/src/components/pages-components/SeeRule/ChangeRuleOrder/ChangeRuleOrder.module.css
@@ -1,9 +1,9 @@
 .sortableContainer {
-  background-color: #2b7a78;
+  background-color: var(--sortable-container-background);
 }
 
 .draggable {
-  background-color: #3aa3a9;
+  background-color: var(--draggable-background);
   color: white;
   padding: 1rem;
   margin: 1rem;

--- a/src/components/pages-components/SeeRule/shared.module.css
+++ b/src/components/pages-components/SeeRule/shared.module.css
@@ -1,13 +1,13 @@
 .ruleTextField fieldset {
-  border: 1px solid #17252a !important;
+  border: 1px solid var(--manage-rules-border) !important;
 }
 
 .ruleTextField input {
-  color: #17252a !important;
+  color: var(--manage-rules-text) !important;
 }
 
 .ruleTextField label {
-  color: #17252a !important;
+  color: var(--manage-rules-text) !important;
 }
 
 .typography {

--- a/src/index.css
+++ b/src/index.css
@@ -1,42 +1,69 @@
 :root {
-  --color-background-for-all-pages: #def2f1;
+  /* ---------- Headers ---------- */
+  --header-background: #2b7a78;
+  --header-text: #feffff;
 
-  --color-text-for-all-headers: #feffff;
-  --color-text-for-all-footers: #17252a;
-  --background-color-for-all-headers: #2b7a78;
+  /* ---------- Footers ---------- */
+  --footer-text: #17252a;
 
-  --color-text-for-btn-login: #feffff;
-  --color-border-for-btn-login: #2b7a78;
-  --color-box-shadow-for-btn-login: #3aafa9;
-  --color-background-for-btn-login: #3aafa9;
-  --color-hover-box-shadow-for-btn-login: #3aafa9;
+  /* ---------- Login Components ---------- */
+  --login-button-background: #3aafa9;
+  --login-button-text: #feffff;
+  --login-button-border: #2b7a78;
+  --login-button-shadow: #3aafa9;
 
-  --color-box-shadow-for-pulsate: #3aafa9;
+  /* ---------- Info Cards ---------- */
+  --info-card-background: #2b7a78;
+  --info-card-text: #feffff;
 
-  --color-background-for-login-modal: #def2f1;
-  --color-background-for-btn-close-in-modal: #feffff;
+  /* ---------- Modals ---------- */
+  --login-modal-background: #def2f1;
+  --modal-close-button-background: #feffff;
 
-  --color-border-for-datagrid-cell-studenttasks: #feffff;
-  --color-background-for-datagrid-cell-studenttasks: #3aafa9;
-  --color-text-for-datagrid-cell-studenttasks: #feffff;
-  --color-border-right-for-datagrid-cell-studenttasks: #feffff;
+  /* ---------- DataGrid ---------- */
+  --datagrid-cell-border: #feffff;
+  --datagrid-cell-background: #3aafa9;
+  --datagrid-cell-text: #feffff;
+  --datagrid-cell-border-right: #feffff;
+  --datagrid-header-border-right: #feffff;
+  --datagrid-header-background: #2b7a78;
+  --datagrid-header-text: #feffff;
 
-  --color-border-right-dataGrid-columnHeader-studenttasks: #feffff;
-  --color-background-dataGrid-columnHeader-studenttasks: #2b7a78;
-  --color-text-dataGrid-columnHeader-studenttasks: #feffff;
+  /* ---------- Input Date ---------- */
+  --input-date-text: #feffff;
+  --input-date-border: #3aafa9;
+  --input-date-fieldset-border: #feffff;
 
-  --color-circular-progress: #3aafa9;
+  /* ---------- Manage Rules ---------- */
+  --manage-rules-border: #17252a;
+  --manage-rules-text: #17252a;
 
-  --color-primary: #2b7a78;
-  --color-secondary: #3aafa9;
-  --color-light: #feffff;
-  --color-text: #17252a;
-  --color-border: #c1c8e4;
+  /* ---------- Change Rule Order ---------- */
+  --sortable-container-background: #2b7a78;
+  --draggable-background: #3aa3a9;
+
+  /* ---------- Tasks List ---------- */
+  --tasks-list-background: #2b7878;
+
+  /* ---------- Student Tasks Header ---------- */
+  --student-tasks-header-background: #2b7a78;
+  --student-tasks-header-text: #feffff;
+
+  /* ---------- Misc ---------- */
+  --page-background: #def2f1;
+  --primary-color: #2b7a78;
+  --secondary-color: #3aafa9;
+  --light-color: #feffff;
+  --dark-color: #17252a;
+  --border-color: #c1c8e4;
+  --progress-color: #3aafa9;
+  --selection-background: #3aafa9;
+  --selection-text: #17252a;
 }
 
 ::selection {
-  background-color: #3aafa9;
-  color: #17252a;
+  background-color: var(--selection-background);
+  color: var(--selection-text);
 }
 
 * {
@@ -51,7 +78,7 @@ html {
 }
 
 body {
-  background-color: var(--color-background-for-all-pages) !important;
+  background-color: var(--page-background) !important;
   background-repeat: no-repeat;
   background-attachment: fixed;
 }
@@ -64,13 +91,10 @@ body {
 }
 
 .dataGrid .MuiDataGrid-root .MuiDataGrid-cell {
-  border-color: var(--color-border-for-datagrid-cell-studenttasks) !important;
-  background-color: var(
-    --color-background-for-datagrid-cell-studenttasks
-  ) !important;
-  color: var(--color-text-for-datagrid-cell-studenttasks) !important;
-  border-right: 2px solid
-    var(--color-border-right-for-datagrid-cell-studenttasks) !important;
+  border-color: var(--datagrid-cell-border) !important;
+  background-color: var(--datagrid-cell-background) !important;
+  color: var(--datagrid-cell-text) !important;
+  border-right: 2px solid var(--datagrid-cell-border-right) !important;
   text-align: center !important;
   font-size: 18px;
   text-overflow: ellipsis !important;
@@ -79,12 +103,9 @@ body {
 }
 
 .dataGrid .MuiDataGrid-root .MuiDataGrid-columnHeader {
-  border-right: 2px solid
-    var(--color-border-right-dataGrid-columnHeader-studenttasks) !important;
-  background-color: var(
-    --color-background-dataGrid-columnHeader-studenttasks
-  ) !important;
-  color: var(--color-text-dataGrid-columnHeader-studenttasks);
+  border-right: 2px solid var(--datagrid-header-border-right) !important;
+  background-color: var(--datagrid-header-background) !important;
+  color: var(--datagrid-header-text);
   font-size: 20px;
 }
 
@@ -96,8 +117,8 @@ body {
 
 button,
 .btn {
-  background-color: #3aafa9 !important;
-  color: #feffff !important;
+  background-color: var(--login-button-background) !important;
+  color: var(--login-button-text) !important;
   transition: all 0.3s !important;
   text-decoration: none;
   padding: 0.5rem;
@@ -108,44 +129,45 @@ button,
 
 button:hover,
 .btn:hover {
-  background-color: #feffff !important;
-  color: #3aafa9 !important;
-  box-shadow: 0 0 20px #3aafa9, 0 0 40px #3aafa9 !important;
+  background-color: var(--login-button-text) !important;
+  color: var(--login-button-background) !important;
+  box-shadow: 0 0 20px var(--login-button-shadow),
+    0 0 40px var(--login-button-shadow) !important;
 }
 
 .MuiCheckbox-root {
-  color: var(--color-text-dataGrid-columnHeader-studenttasks) !important;
+  color: var(--datagrid-header-text) !important;
 }
 
 .table {
-  background-color: #2b7a78 !important;
-  color: #feffff !important;
+  background-color: var(--primary-color) !important;
+  color: var(--light-color) !important;
 }
 
 .table-cell {
-  color: #feffff !important;
+  color: var(--light-color) !important;
 }
 
 .default-text-field fieldset {
-  border: 1px solid #feffff !important;
+  border: 1px solid var(--input-date-fieldset-border) !important;
 }
 
 .default-text-field textarea,
 .default-text-field input,
 .default-text-field label {
-  color: #feffff !important;
+  color: var(--light-color) !important;
 }
 
 .MuiTable-root {
-  background-color: #2b7a78 !important;
+  background-color: var(--primary-color) !important;
 }
 
 .MuiPickersLayout-root button {
-  background-color: #feffff !important;
-  color: #3aa3a9 !important;
+  background-color: var(--light-color) !important;
+  color: var(--draggable-background) !important;
 }
 
 .MuiPickersLayout-root .Mui-selected {
-  background-color: #3aa3a9 !important;
-  color: #feffff !important;
+  background-color: var(--draggable-background) !important;
+  color: var(--light-color) !important;
 }

--- a/src/pages/Course/Course.module.css
+++ b/src/pages/Course/Course.module.css
@@ -6,9 +6,9 @@
 }
 
 .modalText {
-  background-color: #3aafa9;
+  background-color: var(--login-button-background);
   padding: 2rem 6rem;
-  color: #feffff;
+  color: var(--light-color);
 }
 
 .outlet {
@@ -28,7 +28,7 @@
 }
 
 .editButton {
-  background-color: #2b7a78 !important;
+  background-color: var(--header-background) !important;
   margin-right: 1rem !important;
 }
 

--- a/src/pages/ExistingRuleCategories/ExistingRuleCategories.module.css
+++ b/src/pages/ExistingRuleCategories/ExistingRuleCategories.module.css
@@ -1,11 +1,11 @@
 .existingRuleCategories {
-  background-color: #2b7a78 !important;
+  background-color: var(--header-background) !important;
   display: flex;
 }
 
 .existingRuleCategoriesColumns {
-  border-right: 1px solid #feffff;
-  color: #feffff;
+  border-right: 1px solid var(--light-color);
+  color: var(--light-color);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/pages/ManageRules/ManageRules.module.css
+++ b/src/pages/ManageRules/ManageRules.module.css
@@ -17,7 +17,7 @@
 }
 
 .container .ruleLink {
-  background-color: #2b7a78 !important;
+  background-color: var(--header-background) !important;
   white-space: nowrap !important;
   overflow: hidden !important;
   text-overflow: ellipsis !important;

--- a/src/pages/StudentTasks/StudentTasks.module.css
+++ b/src/pages/StudentTasks/StudentTasks.module.css
@@ -1,6 +1,6 @@
 .todoHeader {
-  background-color: #2b7a78;
-  color: #feffff;
+  background-color: var(--student-tasks-header-background);
+  color: var(--student-tasks-header-text);
   text-align: center;
   padding: 20px;
   font-size: 24px;


### PR DESCRIPTION
## Summary
- centralize color variables in `index.css`
- update global styles to use new variables
- update component styles to reference the new variables

## Testing
- `npm run lint` *(fails: cannot find `@eslint/eslintrc`)*

------
https://chatgpt.com/codex/tasks/task_e_6886a50921648330b5c6755b703743cf