### PR TITLE
Reduce Summer Beach cloud count

### DIFF
--- a/src/themes/SummerBeachTheme/Beach.jsx
+++ b/src/themes/SummerBeachTheme/Beach.jsx
@@ -20,7 +20,7 @@ const Beach = () => {
     const leftPositions = [
       ...Array.from(
         { length: cloudCount - 1 },
-        (_, i) => `${10 + (i / (cloudCount - 2)) * 65}vw`
+        (_, i) => `${10 + (i / Math.max(cloudCount - 2, 1)) * 65}vw`
       ),
       "88vw",
     ];

--- a/src/themes/SummerBeachTheme/itemsCount.js
+++ b/src/themes/SummerBeachTheme/itemsCount.js
@@ -1,2 +1,2 @@
 export const rayCount = 20;
-export const cloudCount = 5;
+export const cloudCount = 2;


### PR DESCRIPTION
## Summary
- Limit Summer Beach theme to two clouds
- Guard cloud position logic against division by zero when fewer clouds are used

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f3a25e6148330ad585d801a653262