### PR TITLE
feat(SeeRule): enable Save only when bulk edit points change; persist…

### DIFF
--- a/src/components/pages-components/SeeRule/ChangedRuleCategory/ChangedRuleCategory.jsx
+++ b/src/components/pages-components/SeeRule/ChangedRuleCategory/ChangedRuleCategory.jsx
@@ -4,7 +4,7 @@ import sharedStyles from "../shared.module.css";
 
 function ChangedRuleCategory({ ruleCategory = null, onSaveRuleCategory }) {
   const [newCategoryName, setNewCategoryName] = useState(
-    ruleCategory?.name || "",
+    ruleCategory?.name || ""
   );
 
   async function handleSaveRuleCategory() {
@@ -19,7 +19,7 @@ function ChangedRuleCategory({ ruleCategory = null, onSaveRuleCategory }) {
         className={sharedStyles.ruleTextField}
         label="Rule Category Name"
       />
-      <Button onClick={handleSaveRuleCategory}>Save</Button>
+      <Button onClick={handleSaveRuleCategory}>Save Rule Category</Button>
     </>
   );
 }

--- a/src/components/pages-components/SeeRule/ChangedRuleInput/ChangedRuleInput.jsx
+++ b/src/components/pages-components/SeeRule/ChangedRuleInput/ChangedRuleInput.jsx
@@ -45,7 +45,7 @@ function ChangedRuleInput({
         onClick={handleSaveRuleInput}
         className={styles.saveBtn}
       >
-        Save
+        Save Rule Input
       </Button>
     </div>
   );

--- a/src/components/pages-components/SeeRule/RuleCategory/RuleCategory.jsx
+++ b/src/components/pages-components/SeeRule/RuleCategory/RuleCategory.jsx
@@ -8,6 +8,7 @@ import ChangedRuleInput from "../ChangedRuleInput/ChangedRuleInput";
 import ChangedRuleCategory from "../ChangedRuleCategory/ChangedRuleCategory";
 import { sendAPI } from "../../../../utils/helpers";
 import { baseUrl } from "../../../../utils/config";
+import Spinner from "../../../global-components/Spinner/Spinner.jsx";
 
 function RuleCategory({
   ruleCategory,
@@ -16,13 +17,14 @@ function RuleCategory({
   onSaveRuleInput,
   ruleId,
   setRule,
-  setIsLoading,
 }) {
   const [isEditing, setIsEditing] = useState(false);
   const [isAddingRuleInput, setIsAddingRuleInput] = useState(false);
   const [standardPoints, setStandardPoints] = useState(0);
   const [bulkEditPoints, setBulkEditPoints] = useState(0);
   const [isCollapsed, setIsCollapsed] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
+  const [bulkEditHasChanged, setBulkEditHasChanged] = useState(false);
 
   async function handleEditRuleCategory(...params) {
     await onEditRuleCategory(...params);
@@ -48,11 +50,13 @@ function RuleCategory({
       }
     );
     setRule(rule.data);
-    setBulkEditPoints(0);
+    setBulkEditHasChanged(false);
     setIsLoading(false);
   }
 
-  return (
+  return isLoading ? (
+    <Spinner />
+  ) : (
     <Box className={styles.container}>
       {!isEditing ? (
         <>
@@ -85,23 +89,29 @@ function RuleCategory({
           {!isCollapsed && (
             <Box className={styles.fields}>
               <TextField
+                type="number"
                 label="Standard Points"
                 className={`${sharedStyles.ruleTextField} ${styles.textField}`}
                 value={standardPoints}
-                onChange={(e) => setStandardPoints(e.target.value)}
+                onChange={(e) => setStandardPoints(+e.target.value)}
               />
               <TextField
+                type="number"
                 label="Bulk Edit Points"
                 className={`${sharedStyles.ruleTextField} ${styles.textField}`}
                 value={bulkEditPoints}
-                onChange={(e) => setBulkEditPoints(e.target.value)}
+                onChange={(e) => {
+                  setBulkEditPoints(+e.target.value);
+                  setBulkEditHasChanged(true);
+                }}
               />
               <Button
                 variant="contained"
                 onClick={handleSaveBulkEditPoints}
                 className={styles.actionBtn}
+                disabled={!bulkEditHasChanged}
               >
-                Save
+                Save Bulk Edit Points
               </Button>
             </Box>
           )}

--- a/src/pages/SeeRule/SeeRule.jsx
+++ b/src/pages/SeeRule/SeeRule.jsx
@@ -150,7 +150,6 @@ export default function SeeRule() {
                         onEditRuleCategory={handleSaveRuleCategory}
                         onSaveRuleInput={handleSaveRuleInput}
                         setRule={setRule}
-                        setIsLoading={setIsLoading}
                       />
                     ))}
                     {isAddingRuleCategory ? (


### PR DESCRIPTION
… value and keep panel open

- Track bulkEditHasChanged to gate Save button
- Keep bulk edit value after save; don’t collapse section
- Add local isLoading state with Spinner
- Use number inputs for points