### PR TITLE
feat(theme): centralize Manage Rules button colors across all themes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import { AuthProvider } from "./contexts/AuthContext.jsx";
 import ProtectedRoute from "./components/global-components/ProtectedRoute/ProtectedRoute.jsx";
 import Homepage from "./components/global-components/Homepage/Homepage.jsx";
 import ExistingRuleCategories from "./pages/ExistingRuleCategories/ExistingRuleCategories.jsx";
-import Vibrant from "./themes/VibrantSummerTheme/Vibrant.jsx";
+import Halloween from "./themes/HalloweenTheme/Halloween.jsx";
 import ChangeRuleOrder from "./pages/ChangeRuleOrder/ChangeRuleOrder.jsx";
 import Footer from "./components/global-components/Footer/Footer.jsx";
 
@@ -18,7 +18,7 @@ function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
-        <Vibrant />
+        <Halloween />
         <Routes>
           <Route path="/login" element={<Login />} />
           <Route path="/" element={<Navigate replace to="/home" />} />

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import "./themes/VibrantSummerTheme/colors.css";
+@import "./themes/HalloweenTheme/colors.css";
 
 :root {
   --bg: linear-gradient(180deg, var(--bg1) 0%, var(--bg2) 40%, var(--bg3) 100%);
@@ -12,9 +12,9 @@
   --login-modal-background: var(--bg);
   --info-card-background: var(--header-bg);
 
-  --login-button-background: var(--header-bg);
-  --login-button-text: var(--button-text);
-  --login-button-border: var(--table-border);
+  --login-button-background: linear-gradient(145deg, #2F1B69, #4A2C5A);
+  --login-button-text: #f2f1ff;
+  --login-button-border: #2F1B69;
 
   --info-card-background: var(--header-bg);
 
@@ -201,15 +201,15 @@ body {
 }
 
 table tbody tr:hover {
-  background: #ffffff !important;
+  background: #2F1B14 !important;
 }
 
 .dataGrid .MuiDataGrid-row:hover .MuiDataGrid-cell {
-  background-color: #ffffff !important;
+  background-color: #2F1B14 !important;
 }
 
 .MuiTableRow-root:hover .MuiTableCell-root {
-  background-color: #ffffff !important;
+  background-color: #2F1B14 !important;
 }
 
 button,

--- a/src/pages/ManageRules/ManageRules.module.css
+++ b/src/pages/ManageRules/ManageRules.module.css
@@ -22,9 +22,47 @@
 }
 
 .container .ruleLink {
-  background: var(--header-bg) !important;
+  background: linear-gradient(
+    145deg,
+    var(--manage-rules-btn-bg-start),
+    var(--manage-rules-btn-bg-end)
+  ) !important;
+  color: var(--manage-rules-btn-text) !important;
+  border: 1px solid var(--manage-rules-btn-border) !important;
   white-space: nowrap !important;
   overflow: hidden !important;
   text-overflow: ellipsis !important;
   max-width: 100% !important;
+  padding: 0.6rem 1.15rem !important;
+  border-radius: 999px !important;
+  font-weight: 800 !important;
+  letter-spacing: 0.2px !important;
+  text-decoration: none !important;
+  display: inline-block !important;
+  text-align: center !important;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12) !important;
+  transition: transform 0.2s ease, filter 0.2s ease, background 0.2s ease !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+
+.container .ruleLink:hover {
+  filter: brightness(1.05) !important;
+  transform: translateY(-1px) scale(1.02) !important;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.14) !important;
+  background: linear-gradient(
+    145deg,
+    var(--manage-rules-btn-hover-start),
+    var(--manage-rules-btn-hover-end)
+  ) !important;
+}
+
+.container .ruleLink.btn {
+  background: linear-gradient(
+    145deg,
+    var(--manage-rules-btn-bg-start),
+    var(--manage-rules-btn-bg-end)
+  ) !important;
+  color: var(--manage-rules-btn-text) !important;
+  border: 1px solid var(--manage-rules-btn-border) !important;
 }

--- a/src/pages/Results/Results.module.css
+++ b/src/pages/Results/Results.module.css
@@ -153,7 +153,6 @@
   font-weight: 600;
 }
 
-/* Improve dropdown size/spacing */
 .valueCell .MuiSelect-select {
   padding: 10px 14px !important;
   background: #ffffff !important;

--- a/src/themes/ForestTheme/colors.css
+++ b/src/themes/ForestTheme/colors.css
@@ -25,4 +25,11 @@
   --button-text: #ffffff;
   --results-bg: #ffffff;
   --results-accent: #1a2e20;
+
+  --manage-rules-btn-bg-start: #2f4f2f;
+  --manage-rules-btn-bg-end: #4a6e55;
+  --manage-rules-btn-hover-start: #4a6e55;
+  --manage-rules-btn-hover-end: #5a8c58;
+  --manage-rules-btn-text: #ffffff;
+  --manage-rules-btn-border: #2f4f2f;
 }

--- a/src/themes/HalloweenTheme/Halloween.jsx
+++ b/src/themes/HalloweenTheme/Halloween.jsx
@@ -1,0 +1,93 @@
+import { Box } from "@mui/material";
+import { pumpkinsCount, ghostsCount, starsCount } from "./itemsCount";
+import styles from "./Halloween.module.css";
+import MoonIcon from "./svgs/MoonIcon";
+import BatIcon from "./svgs/BatIcon";
+import PumpkinIcon from "./svgs/PumpkinIcon";
+import GhostIcon from "./svgs/GhostIcon";
+import CauldronIcon from "./svgs/CauldronIcon";
+
+export default function Halloween() {
+  const stars = Array.from({ length: starsCount }, (_, i) => ({
+    size: Math.random() * 0.25 + 0.125,
+    left: Math.random() * 100,
+    top: Math.random() * 100,
+    i,
+    color: i % 2 === 0 ? "#e9e7ff" : "#c9c4ff",
+    animationDelay: i % 2 === 0 ? `-${2.5}s` : `-${3}s`,
+  }));
+
+  const pumpkins = Array.from({ length: pumpkinsCount }, (_, i) => ({
+    left: Math.random() * 90 + 5,
+    top: Math.random() * 85 + 5,
+    i,
+    animationDelay: `${i * 0.5}s`,
+  }));
+
+  const ghosts = Array.from({ length: ghostsCount }, (_, i) => ({
+    top: Math.random() * 90 + 2,
+    i,
+    animationDelay: `-${i * 6}s`,
+  }));
+
+  return (
+    <Box className={styles.halloweenContainer}>
+      <Box className={styles.stars}>
+        {stars.map((star) => (
+          <Box
+            key={star.i}
+            className={styles.star}
+            sx={{
+              width: `${star.size}rem`,
+              height: `${star.size}rem`,
+              left: `${star.left}%`,
+              top: `${star.top}%`,
+              backgroundColor: star.color,
+              animationDelay: star.animationDelay,
+            }}
+          />
+        ))}
+      </Box>
+
+      <MoonIcon className={styles.moon} />
+      <BatIcon className={styles.moonBat} />
+
+      <Box className={styles.pumpkins}>
+        {pumpkins.map((pumpkin) => (
+          <Box
+            key={pumpkin.i}
+            className={styles.pumpkin}
+            sx={{
+              left: `${pumpkin.left}%`,
+              top: `${pumpkin.top}%`,
+              animationDelay: pumpkin.animationDelay,
+            }}
+          >
+            <PumpkinIcon />
+          </Box>
+        ))}
+      </Box>
+
+      <Box className={styles.ghostsLayer}>
+        {ghosts.map((ghost) => (
+          <Box
+            key={ghost.i}
+            className={styles.ghost}
+            sx={{
+              top: `${ghost.top}vh`,
+              animationDelay: ghost.animationDelay,
+            }}
+          >
+            <Box className={styles.ghostBody}>
+              <GhostIcon />
+            </Box>
+          </Box>
+        ))}
+      </Box>
+
+      <Box className={styles.cauldron}>
+        <CauldronIcon />
+      </Box>
+    </Box>
+  );
+}

--- a/src/themes/HalloweenTheme/Halloween.module.css
+++ b/src/themes/HalloweenTheme/Halloween.module.css
@@ -1,0 +1,202 @@
+.halloweenContainer {
+  position: fixed;
+  inset: 0;
+  z-index: -200;
+}
+.stars {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+  overflow: hidden;
+}
+
+.star {
+  animation: twinkle 3s infinite alternate;
+  border-radius: 50%;
+  position: absolute;
+}
+
+@keyframes twinkle {
+  0% {
+    transform: scale(0.5);
+    opacity: 0.6;
+  }
+  50% {
+    transform: scale(1.2);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.8);
+    opacity: 0.7;
+  }
+}
+
+.moon {
+  position: absolute !important;
+  right: 3% !important;
+  top: 1rem !important;
+  width: 8.75rem !important;
+  height: 8.75rem !important;
+  display: block !important;
+  filter: drop-shadow(0 0 2.5rem rgba(246, 235, 170, 0.18))
+    drop-shadow(0 0 1.375rem rgba(246, 235, 170, 0.22)) !important;
+  animation: moonFloat 18s ease-in-out infinite !important;
+  pointer-events: none !important;
+  z-index: 6 !important;
+}
+
+@keyframes moonFloat {
+  0%,
+  100% {
+    transform: translateY(0) rotate(0.2deg);
+  }
+  50% {
+    transform: translateY(0.25rem) rotate(-0.3deg);
+  }
+}
+
+.moonBat {
+  position: absolute !important;
+  top: 3.5rem !important;
+  right: calc(3% + 8rem) !important;
+  width: 8.75rem !important;
+  height: auto !important;
+  transform: rotate(-6deg);
+  opacity: 0.95 !important;
+  z-index: 6 !important;
+  pointer-events: none !important;
+  filter: drop-shadow(0 0 0.375rem rgba(0, 255, 120, 0.6)) !important;
+}
+
+.pumpkins {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.pumpkin {
+  position: absolute;
+  animation: pumpkinBob 3s ease-in-out infinite;
+  z-index: -100;
+}
+
+.pumpkin svg {
+  width: 6.25rem;
+  height: 6.25rem;
+  overflow: visible;
+  animation: faceFlicker 2.4s infinite steps(2, end);
+}
+
+@keyframes pumpkinBob {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-0.5rem);
+  }
+}
+
+@keyframes faceFlicker {
+  0%,
+  7% {
+    filter: drop-shadow(0 0 0.4375rem rgba(255, 160, 60, 0.25))
+      drop-shadow(0 0 0.875rem rgba(255, 120, 0, 0.18));
+  }
+  8%,
+  10% {
+    filter: drop-shadow(0 0 0.0625rem rgba(255, 160, 60, 0.05));
+  }
+  11%,
+  49% {
+    filter: drop-shadow(0 0 0.5625rem rgba(255, 170, 70, 0.35))
+      drop-shadow(0 0 1.125rem rgba(255, 120, 0, 0.25));
+  }
+  50% {
+    filter: drop-shadow(0 0 0.1875rem rgba(255, 160, 60, 0.12));
+  }
+  51%,
+  100% {
+    filter: drop-shadow(0 0 0.75rem rgba(255, 175, 70, 0.45))
+      drop-shadow(0 0 1.5rem rgba(255, 120, 0, 0.35));
+  }
+}
+
+.ghosts {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2000 !important;
+}
+
+.ghost {
+  position: absolute;
+  left: -20vw;
+  opacity: 0.6;
+  width: 6rem;
+  height: 4.5rem;
+  animation: glide 22s linear infinite;
+  z-index: 2000 !important;
+}
+
+.ghost:nth-child(2) {
+  bottom: 48vh;
+  animation: glide 24s linear infinite -6s;
+}
+
+.ghost:nth-child(3) {
+  bottom: 66vh;
+  animation: glide 28s linear infinite -12s;
+}
+
+.ghost svg {
+  width: 100%;
+  height: 100%;
+  z-index: 1000 !important;
+}
+
+@keyframes glide {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(140vw);
+  }
+}
+
+.ghostBody {
+  animation: sway 3.2s ease-in-out infinite;
+  position: relative;
+  z-index: 1000 !important;
+  width: 100% !important;
+  height: 100% !important;
+}
+
+@keyframes sway {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-0.25rem);
+  }
+}
+
+.cauldron {
+  position: fixed;
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%);
+  z-index: 20;
+  pointer-events: none;
+}
+
+.cauldron svg {
+  width: 18.75rem;
+  height: 13.75rem;
+  overflow: visible;
+}

--- a/src/themes/HalloweenTheme/colors.css
+++ b/src/themes/HalloweenTheme/colors.css
@@ -1,0 +1,46 @@
+:root {
+  --bg1: #171a33;
+  --bg2: #1e2142;
+  --bg3: #12152c;
+
+  --header-start: transparent;
+  --header-end: transparent;
+  --header-text: #f2f1ff;
+
+  --footer-start: #120f24;
+  --footer-end: #171332;
+  --footer-text: #c9c6ff;
+
+  --border-see-rule: #2d2a4f;
+
+  --table-header: rgba(33, 28, 62, 0.7);
+  --table-border: #ff7a00;
+  --table-text-color: #f2f1ff;
+  --row-odd: rgba(30, 25, 56, 0.6);
+  --row-even: rgba(42, 36, 72, 0.6);
+
+  --accent: #ff7a00;
+  --highlight: #35ff6b;
+  --main-text: #f2f1ff;
+  --button-text: #f2f1ff;
+  --results-bg: rgba(30, 33, 66, 0.7);
+  --results-accent: #ff7a00;
+
+  --login-button-background: linear-gradient(145deg, #2f1b69, #4a2c5a);
+  --login-button-text: #f2f1ff;
+  --login-button-border: #2f1b69;
+
+  --primary-color: linear-gradient(145deg, #2f1b69, #4a2c5a);
+  --secondary-color: #2f1b69;
+
+  --manage-rules-button-bg: linear-gradient(145deg, #35ff6b, #4aff7e);
+  --manage-rules-button-text: #0a1a0f;
+  --manage-rules-button-border: #35ff6b;
+
+  --manage-rules-btn-bg-start: #2f1b69;
+  --manage-rules-btn-bg-end: #4a2c5a;
+  --manage-rules-btn-hover-start: #4a2c5a;
+  --manage-rules-btn-hover-end: #5d3a6b;
+  --manage-rules-btn-text: #f2f1ff;
+  --manage-rules-btn-border: #2f1b69;
+}

--- a/src/themes/HalloweenTheme/itemsCount.js
+++ b/src/themes/HalloweenTheme/itemsCount.js
@@ -1,0 +1,3 @@
+export const pumpkinsCount = 4;
+export const ghostsCount = 6;
+export const starsCount = 50;

--- a/src/themes/HalloweenTheme/svgs/BatIcon.jsx
+++ b/src/themes/HalloweenTheme/svgs/BatIcon.jsx
@@ -1,0 +1,28 @@
+import { Box, SvgIcon } from "@mui/material";
+
+function BatIcon() {
+  return (
+    <SvgIcon viewBox="0 0 90 36">
+      <Box component="g" fill="#2b2a4d">
+        <Box
+          component="path"
+          d="M45 14
+         c3-6 10-10 18-12 9-3 18-3 26-1
+         -7 3 -12 6 -15 10
+         8 2 15 5 21 10
+         -14-1 -26 0 -34 3
+         -5 7 -10 10 -16 10
+         s-11-3 -16-10
+         c-8-3 -20-4 -34-3
+         6-5 13-8 21-10
+         -3-4 -8-7 -15-10
+         8-2 17-2 26 1
+         8 2 15 6 18 12z"
+        />
+        <Box component="path" d="M38 12 l4-7 3 7z" />
+        <Box component="path" d="M48 12 l3-7 4 7z" />
+      </Box>
+    </SvgIcon>
+  );
+}
+export default BatIcon;

--- a/src/themes/HalloweenTheme/svgs/CauldronIcon.jsx
+++ b/src/themes/HalloweenTheme/svgs/CauldronIcon.jsx
@@ -1,0 +1,288 @@
+import { Box, SvgIcon } from "@mui/material";
+
+function CauldronIcon() {
+  return (
+    <SvgIcon viewBox="0 0 520 460">
+      <Box component="defs">
+        <Box component="radialGradient" id="backGlow" cx="50%" cy="55%" r="70%">
+          <Box
+            component="stop"
+            offset="0%"
+            stopColor="#2cff6a"
+            stopOpacity="0.6"
+          />
+          <Box
+            component="stop"
+            offset="50%"
+            stopColor="#22c555"
+            stopOpacity="0.25"
+          />
+          <Box
+            component="stop"
+            offset="100%"
+            stopColor="#0a1a0f"
+            stopOpacity="0"
+          />
+        </Box>
+        <Box
+          component="radialGradient"
+          id="potionGlow"
+          cx="50%"
+          cy="50%"
+          r="80%"
+        >
+          <Box
+            component="stop"
+            offset="0%"
+            stopColor="#b6ff73"
+            stopOpacity="1"
+          />
+          <Box
+            component="stop"
+            offset="70%"
+            stopColor="#38a30c"
+            stopOpacity="0.7"
+          />
+          <Box
+            component="stop"
+            offset="100%"
+            stopColor="#0c2d00"
+            stopOpacity="0"
+          />
+        </Box>
+        <Box
+          component="radialGradient"
+          id="potionSurface"
+          cx="50%"
+          cy="40%"
+          r="70%"
+        >
+          <Box component="stop" offset="0%" stopColor="#d6ffd0" />
+          <Box component="stop" offset="100%" stopColor="#1fa33b" />
+        </Box>
+        <Box component="filter" id="blur15">
+          <Box component="feGaussianBlur" stdDeviation="15" />
+        </Box>
+        <Box component="filter" id="softGlow">
+          <Box component="feGaussianBlur" stdDeviation="25" />
+        </Box>
+      </Box>
+
+      <Box
+        component="rect"
+        x="0"
+        y="0"
+        width="520"
+        height="460"
+        fill="#0b1f0d"
+      />
+      <Box
+        component="rect"
+        x="0"
+        y="0"
+        width="520"
+        height="460"
+        fill="url(#backGlow)"
+        filter="url(#softGlow)"
+        opacity="0.85"
+      />
+      <Box
+        component="circle"
+        cx="260"
+        cy="120"
+        r="240"
+        fill="url(#potionGlow)"
+        filter="url(#blur15)"
+        opacity="0.8"
+      />
+
+      <Box
+        component="path"
+        d="M60,200 C60,120 160,80 260,76
+       C360,80 460,120 460,200
+       C460,340 360,420 260,428
+       C160,420 60,340 60,200 Z"
+        fill="#0a0a0f"
+        stroke="#000"
+        strokeWidth="6"
+      />
+
+      <Box
+        component="rect"
+        x="150"
+        y="400"
+        width="50"
+        height="30"
+        rx="8"
+        fill="#000"
+      />
+      <Box
+        component="rect"
+        x="320"
+        y="400"
+        width="50"
+        height="30"
+        rx="8"
+        fill="#000"
+      />
+
+      <Box component="ellipse" cx="260" cy="116" rx="200" ry="50" fill="#000" />
+      <Box component="ellipse" cx="260" cy="116" rx="176" ry="36" fill="#111" />
+
+      <Box
+        component="ellipse"
+        cx="260"
+        cy="116"
+        rx="176"
+        ry="36"
+        fill="url(#potionSurface)"
+      />
+
+      <Box
+        component="path"
+        d="M370,116 q10,30 0,60 q-12,-6 -6,-40z"
+        fill="url(#potionSurface)"
+      />
+      <Box
+        component="path"
+        d="M160,116 q8,28 -2,50 q-10,-6 -4,-36z"
+        fill="url(#potionSurface)"
+      />
+
+      <Box
+        component="circle"
+        cx="240"
+        cy="112"
+        r="12"
+        fill="url(#potionSurface)"
+      />
+      <Box
+        component="circle"
+        cx="280"
+        cy="112"
+        r="10"
+        fill="url(#potionSurface)"
+      />
+
+      <Box component="g" fill="#b6ffdd" opacity="0.9">
+        <Box component="circle" cx="260" cy="116" r="14">
+          <Box
+            component="animate"
+            attributeName="cy"
+            values="116;20"
+            dur="5s"
+            repeatCount="indefinite"
+          />
+          <Box
+            component="animate"
+            attributeName="opacity"
+            values="1;0;1"
+            dur="5s"
+            repeatCount="indefinite"
+          />
+        </Box>
+        <Box component="circle" cx="290" cy="116" r="12">
+          <Box
+            component="animate"
+            attributeName="cy"
+            values="116;40"
+            dur="4s"
+            begin="1s"
+            repeatCount="indefinite"
+          />
+          <Box
+            component="animate"
+            attributeName="opacity"
+            values="1;0;1"
+            dur="4s"
+            begin="1s"
+            repeatCount="indefinite"
+          />
+        </Box>
+        <Box component="circle" cx="230" cy="116" r="10">
+          <Box
+            component="animate"
+            attributeName="cy"
+            values="116;60"
+            dur="4.5s"
+            begin="0.7s"
+            repeatCount="indefinite"
+          />
+          <Box
+            component="animate"
+            attributeName="opacity"
+            values="1;0;1"
+            dur="4.5s"
+            begin="0.7s"
+            repeatCount="indefinite"
+          />
+        </Box>
+      </Box>
+      <Box component="g" opacity="0.95">
+        {[
+          { x: 180, y: 60, r: 9, c: "#7aff9a", d: "3s" },
+          { x: 340, y: 80, r: 11, c: "#a0ffff", d: "4s" },
+          { x: 210, y: 90, r: 4, c: "#ff7a00", d: "2.2s" },
+          { x: 300, y: 40, r: 5, c: "#f7ff91", d: "2.8s" },
+          { x: 380, y: 70, r: 4, c: "#ff78d9", d: "3.1s" },
+          { x: 120, y: 80, r: 4, c: "#7aff9a", d: "2.6s" },
+          { x: 430, y: 100, r: 3, c: "#ffd166", d: "2.4s" },
+          { x: 250, y: 60, r: 4, c: "#64b5ff", d: "2.3s" },
+          { x: 160, y: 120, r: 3, c: "#ffd166", d: "2.1s" },
+          { x: 400, y: 150, r: 3, c: "#c084ff", d: "2.7s" },
+        ].map((s, i) => (
+          <Box
+            key={i}
+            component="circle"
+            cx={`${s.x}`}
+            cy={`${s.y}`}
+            r={`${s.r}`}
+            fill={s.c}
+          >
+            <Box
+              component="animate"
+              attributeName="opacity"
+              values="0.6;1;0.6"
+              dur={s.d}
+              repeatCount="indefinite"
+            />
+            <Box
+              component="animate"
+              attributeName="r"
+              values={`${s.r};${s.r + 3};${s.r}`}
+              dur={s.d}
+              repeatCount="indefinite"
+            />
+          </Box>
+        ))}
+        {[
+          { x: 240, y: 60 },
+          { x: 280, y: 30 },
+          { x: 160, y: 45 },
+          { x: 400, y: 55 },
+          { x: 450, y: 140 },
+          { x: 120, y: 140 },
+        ].map((t, i) => (
+          <Box
+            key={`tw-${i}`}
+            component="circle"
+            cx={`${t.x}`}
+            cy={`${t.y}`}
+            r="2"
+            fill="#ffffff"
+          >
+            <Box
+              component="animate"
+              attributeName="opacity"
+              values="1;0.2;1"
+              dur="2.5s"
+              repeatCount="indefinite"
+            />
+          </Box>
+        ))}
+      </Box>
+    </SvgIcon>
+  );
+}
+
+export default CauldronIcon;

--- a/src/themes/HalloweenTheme/svgs/GhostIcon.jsx
+++ b/src/themes/HalloweenTheme/svgs/GhostIcon.jsx
@@ -1,0 +1,25 @@
+import { Box, SvgIcon } from "@mui/material";
+
+function GhostIcon() {
+  return (
+    <SvgIcon viewBox="0 0 120 90">
+      <Box
+        component="path"
+        fill="#fff"
+        d="M60 10c-22 0-36 14-36 34v36l10-6 10 6 10-6 10 6 10-6 10 6V44C84 24 72 10 60 10z"
+      />
+      <Box component="circle" cx="48" cy="40" r="5" fill="#0d0b1a" />
+      <Box component="circle" cx="72" cy="40" r="5" fill="#0d0b1a" />
+      <Box
+        component="path"
+        d="M54 54 q6 6 12 0"
+        stroke="#0d0b1a"
+        strokeWidth="5"
+        fill="none"
+        strokeLinecap="round"
+      />
+    </SvgIcon>
+  );
+}
+
+export default GhostIcon;

--- a/src/themes/HalloweenTheme/svgs/MoonIcon.jsx
+++ b/src/themes/HalloweenTheme/svgs/MoonIcon.jsx
@@ -1,0 +1,53 @@
+import { Box, SvgIcon } from "@mui/material";
+
+function MoonIcon() {
+  return (
+    <SvgIcon viewBox="0 0 160 160">
+      <Box component="defs">
+        <Box
+          component="filter"
+          id="noisy"
+          x="-20%"
+          y="-20%"
+          width="140%"
+          height="140%"
+        >
+          <Box
+            component="feTurbulence"
+            type="fractalNoise"
+            baseFrequency="0.9"
+            numOctaves="1"
+            result="n"
+          />
+          <Box
+            component="feDisplacementMap"
+            in="SourceGraphic"
+            in2="n"
+            scale="2"
+          />
+        </Box>
+      </Box>
+      <Box
+        component="circle"
+        cx="80"
+        cy="80"
+        r="68"
+        fill="#f2e6b3"
+        filter="url(#noisy)"
+      />
+      <Box
+        component="path"
+        d="M28,80a52,52 0 1,0 104,0a60,60 0 1,1 -104,0Z"
+        fill="#2b2548"
+        opacity="0.28"
+      />
+      <Box component="circle" cx="52" cy="62" r="9" fill="#d8cfa2" />
+      <Box component="circle" cx="96" cy="54" r="6" fill="#d8cfa2" />
+      <Box component="circle" cx="72" cy="96" r="7" fill="#d8cfa2" />
+      <Box component="circle" cx="112" cy="92" r="5" fill="#d8cfa2" />
+      <Box component="circle" cx="44" cy="102" r="6" fill="#d8cfa2" />
+    </SvgIcon>
+  );
+}
+
+export default MoonIcon;

--- a/src/themes/HalloweenTheme/svgs/PumpkinIcon.jsx
+++ b/src/themes/HalloweenTheme/svgs/PumpkinIcon.jsx
@@ -1,0 +1,32 @@
+import { Box, SvgIcon } from "@mui/material";
+
+function PumpkinIcon() {
+  return (
+    <SvgIcon viewBox="0 0 72 72">
+      <Box component="ellipse" cx="36" cy="42" rx="24" ry="18" fill="#ff7a00" />
+      <Box component="ellipse" cx="26" cy="42" rx="14" ry="17" fill="#ff952e" />
+      <Box component="ellipse" cx="46" cy="42" rx="14" ry="17" fill="#ff952e" />
+      <Box component="ellipse" cx="36" cy="42" rx="9" ry="17" fill="#ffb457" />
+      <Box
+        component="rect"
+        x="33"
+        y="18"
+        width="6"
+        height="10"
+        rx="2"
+        fill="#2a8a2a"
+      />
+      <Box component="polygon" points="24,36 32,32 32,40" fill="#1a0f1a" />
+      <Box component="polygon" points="48,36 40,32 40,40" fill="#1a0f1a" />
+      <Box component="polygon" points="36,41 33,39 39,39" fill="#1a0f1a" />
+      <Box
+        component="path"
+        d="M18 48 L26 50 L28 46 L32 50 L36 46 L40 50 L44 46 L46 50 L54 48
+               Q50 58 36 58 Q22 58 18 48Z"
+        fill="#1a0f1a"
+      />
+    </SvgIcon>
+  );
+}
+
+export default PumpkinIcon;

--- a/src/themes/OceanTheme/colors.css
+++ b/src/themes/OceanTheme/colors.css
@@ -25,4 +25,11 @@
   --button-text: #def2f1;
   --results-bg: #def2f1;
   --results-accent: #187bcd;
+
+  --manage-rules-btn-bg-start: #172a4a;
+  --manage-rules-btn-bg-end: #187bcd;
+  --manage-rules-btn-hover-start: #187bcd;
+  --manage-rules-btn-hover-end: #3aafa9;
+  --manage-rules-btn-text: #def2f1;
+  --manage-rules-btn-border: #172a4a;
 }

--- a/src/themes/SummerBeachTheme/colors.css
+++ b/src/themes/SummerBeachTheme/colors.css
@@ -42,4 +42,11 @@
   --row-odd: rgba(255, 255, 255, 0.25);
   --row-even: rgba(255, 255, 255, 0.15);
   --results-bg: #fdf1d7;
+
+  --manage-rules-btn-bg-start: #0c7bb3;
+  --manage-rules-btn-bg-end: #2eb5e5;
+  --manage-rules-btn-hover-start: #2eb5e5;
+  --manage-rules-btn-hover-end: #82ccef;
+  --manage-rules-btn-text: #062b2b;
+  --manage-rules-btn-border: #0c7bb3;
 }

--- a/src/themes/VibrantSummerTheme/colors.css
+++ b/src/themes/VibrantSummerTheme/colors.css
@@ -25,4 +25,11 @@
   --row-even: #ffe6b4;
   --results-bg: rgba(255, 255, 255, 0.94);
   --results-accent: #ff6f61;
+
+  --manage-rules-btn-bg-start: #ffb02e;
+  --manage-rules-btn-bg-end: #00c2a8;
+  --manage-rules-btn-hover-start: #ff6f61;
+  --manage-rules-btn-hover-end: #00c2a8;
+  --manage-rules-btn-text: #253133;
+  --manage-rules-btn-border: #ffb02e;
 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -3,6 +3,7 @@ export const sendAPI = async function (
   url,
   data = { nothing: null }
 ) {
+  console.log(url);
   try {
     let dataReturned;
     if (typeOfRequest === "GET")


### PR DESCRIPTION
Add Manage Rules CSS variables to Forest, Ocean, SummerBeach, and VibrantSummer themes Update ManageRules.module.css to consume theme variables (bg start/end, hover, text, border) Keep Halloween theme tokens aligned
Result: button styling now fully theme-driven; no hard-coded colors in page CSS